### PR TITLE
Fixing the height of CK+ calc poke-title class

### DIFF
--- a/ck+/style.css
+++ b/ck+/style.css
@@ -509,7 +509,7 @@ input:checked + .fake-checkbox {
 .poke-title {
 	column-width: 100px;
 	border-spacing: 0px;
-	height: 88px;
+	height: 99px;
 }
 
 .poke-title td:first-child {


### PR DESCRIPTION
The left side is currently ever so slightly misaligned with the right side, and it's because the poke-title class's height is not tall enough to properly accomodate, so it just defaults to using the heights of the elements inside. It's slightly variable on zoom level because of rounding.

![image](https://github.com/user-attachments/assets/2d3db745-edda-44a1-b66b-590c07b115c3)
